### PR TITLE
Unify and update ProgLearn urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,11 @@ being contribution of code or documentation to the project. Improving the
 documentation is no less important than improving the library itself. If you
 find a typo in the documentation, or have made improvements, do not hesitate to
 submit a GitHub pull request. Documentation can be found under the
-[docs/](https://github.com/neurodata/progressive-learning/tree/master/docs) directory.
+[docs/](https://github.com/neurodata/ProgLearn/tree/master/docs) directory.
 
 But there are many other ways to help. In particular answering queries on the
-[issue tracker](https://github.com/neurodata/progressive-learning/issues), and
-investigating bugs are very valuable contributions that decrease the burden on 
+[issue tracker](https://github.com/neurodata/ProgLearn/issues), and
+investigating bugs are very valuable contributions that decrease the burden on
 the project maintainers.
 
 Another way to contribute is to report issues you're facing, and give a "thumbs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ being contribution of code or documentation to the project. Improving the
 documentation is no less important than improving the library itself. If you
 find a typo in the documentation, or have made improvements, do not hesitate to
 submit a GitHub pull request. Documentation can be found under the
-[docs/](https://github.com/neurodata/ProgLearn/tree/master/docs) directory.
+[docs/](https://github.com/neurodata/ProgLearn/tree/main/docs) directory.
 
 But there are many other ways to help. In particular answering queries on the
 [issue tracker](https://github.com/neurodata/ProgLearn/issues), and

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ The progressive learning package utilizes representation ensembling algorithms t
 
 # System Requirements
 ## Hardware requirements
-`proglearn` package requires only a standard computer with enough RAM to support the in-memory operations. 
+`proglearn` package requires only a standard computer with enough RAM to support the in-memory operations.
 
 ## Software requirements
 ### OS Requirements
 This package is supported for *Linux* and *macOS*. The package has been tested on the following systems:
 + Linux: Ubuntu 16.04
 + macOS: Mojave (10.14.1)
-+ Windows: 10 
++ Windows: 10
 
 ### Python Requirements
 This package is written for Python3. Currently, it is supported for Python 3.6 and 3.7.
@@ -46,7 +46,7 @@ scikit-learn>=0.22.0
 scipy==1.4.1
 numpy<1.19
 joblib>=0.14.1
-``` 
+```
 
 # Installation Guide
 ## Install from pip
@@ -56,25 +56,25 @@ pip install proglearn
 
 ## Install from Github
 ```
-git clone https://github.com/neurodata/progressive-learning.git
-cd progressive-learning
+git clone https://github.com/neurodata/ProgLearn.git
+cd ProgLearn
 python3 setup.py install
 ```
 
 # Contributing
-We welcome contributions from anyone. Please see our [contribution guidelines](https://github.com/neurodata/progressive-learning/blob/master/CONTRIBUTING.md) before making a pull request. Our 
-[issues](https://github.com/neurodata/progressive-learning/issues) page is full of places we could use help! 
-If you have an idea for an improvement not listed there, please 
-[make an issue](https://github.com/neurodata/progressive-learning/issues/new) first so you can discuss with the 
-developers. 
+We welcome contributions from anyone. Please see our [contribution guidelines](https://github.com/neurodata/ProgLearn/blob/master/CONTRIBUTING.md) before making a pull request. Our
+[issues](https://github.com/neurodata/ProgLearn/issues) page is full of places we could use help!
+If you have an idea for an improvement not listed there, please
+[make an issue](https://github.com/neurodata/ProgLearn/issues/new) first so you can discuss with the
+developers.
 
 # License
-This project is covered under the [MIT License](hhttps://github.com/neurodata/progressive-learning/blob/master/LICENSE).
+This project is covered under the [MIT License](https://github.com/neurodata/ProgLearn/blob/master/LICENSE).
 
 # Issues
-We appreciate detailed bug reports and feature requests (though we appreciate pull requests even more!). Please visit our [issues](https://github.com/neurodata/progressive-learning/issues) page if you have questions or ideas.
+We appreciate detailed bug reports and feature requests (though we appreciate pull requests even more!). Please visit our [issues](https://github.com/neurodata/ProgLearn/issues) page if you have questions or ideas.
 
-# Citing progressive-learning
-If you find progressive-learning useful in your work, please cite the package via the [progressive-learning paper](https://arxiv.org/pdf/2004.12908.pdf)
+# Citing ProgLearn
+If you find ProgLearn useful in your work, please cite the package via the [progressive-learning paper](https://arxiv.org/pdf/2004.12908.pdf)
 
 > Vogelstein JT, Helm HS, Mehta RD, Dey J, Yang W, Tower B, LeVine W, Larson J, White C, Priebe CE. A general approach to progressive learning. arXiv preprint arXiv:2004.12908. 2020 Apr 27.

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ python3 setup.py install
 ```
 
 # Contributing
-We welcome contributions from anyone. Please see our [contribution guidelines](https://github.com/neurodata/ProgLearn/blob/master/CONTRIBUTING.md) before making a pull request. Our
+We welcome contributions from anyone. Please see our [contribution guidelines](https://github.com/neurodata/ProgLearn/blob/main/CONTRIBUTING.md) before making a pull request. Our
 [issues](https://github.com/neurodata/ProgLearn/issues) page is full of places we could use help!
 If you have an idea for an improvement not listed there, please
 [make an issue](https://github.com/neurodata/ProgLearn/issues/new) first so you can discuss with the
 developers.
 
 # License
-This project is covered under the [MIT License](https://github.com/neurodata/ProgLearn/blob/master/LICENSE).
+This project is covered under the [MIT License](https://github.com/neurodata/ProgLearn/blob/main/LICENSE).
 
 # Issues
 We appreciate detailed bug reports and feature requests (though we appreciate pull requests even more!). Please visit our [issues](https://github.com/neurodata/ProgLearn/issues) page if you have questions or ideas.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -11,15 +11,15 @@ an issue if you have found a bug or wish to see a feature implemented.
 
 In case you experience issues using this package, do not hesitate to submit a
 ticket to the
-`Issue Tracker <https://github.com/neurodata/progressive-learning/issues>`_. You are
+`Issue Tracker <https://github.com/neurodata/ProgLearn/issues>`_. You are
 also welcome to post feature requests or pull requests.
 
 It is recommended to check that your issue complies with the
 following rules before submitting:
 
 -  Verify that your issue is not being currently addressed by other
-   `issues <https://github.com/neurodata/progressive-learning/issues?q=>`_
-   or `pull requests <https://github.com/neurodata/progressive-learning/pulls?q=>`_.
+   `issues <https://github.com/neurodata/ProgLearn/issues?q=>`_
+   or `pull requests <https://github.com/neurodata/ProgLearn/pulls?q=>`_.
 
 -  If you are submitting a bug report, we strongly encourage you to follow the
    guidelines in :ref:`filing_bugs`.
@@ -64,7 +64,7 @@ Contributing Code
 The preferred workflow for contributing to `ProgLearn` is to fork the staging
 repository on GitHub, clone, and develop on a branch. Steps:
 
-1. Fork the `project repository <https://github.com/neurodata/progressive-learning>`__ by clicking
+1. Fork the `project repository <https://github.com/neurodata/ProgLearn>`__ by clicking
    on the ‘Fork’ button near the top right of the page. This creates a copy
    of the code under your GitHub user account. For more details on how to
    fork a repository see `this
@@ -75,8 +75,8 @@ repository on GitHub, clone, and develop on a branch. Steps:
 
    .. code:: bash
 
-      $ git clone git@github.com:YourLogin/progressive-learning.git
-      $ cd progressive-learning
+      $ git clone git@github.com:YourLogin/ProgLearn.git
+      $ cd ProgLearn
 
 3. Create a ``feature`` branch to hold your development changes:
 
@@ -146,11 +146,11 @@ before you submit a pull request:
 
       $ pip install black
       $ black path/to/module.py
-      
+
 - PR into ``staging``. In this PR, link relevant issues (either via the use of `closing keywords <https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords/>`__ in the comment or by directly linking relevant issues on the lower righthand side of the PR from the web interface), summarize the PR in the title, and comment on the PR with the following format:
 
   .. code:: bash
-  
+
       #### Reference issue
       <Example: Closes gh-WXYZ>
 
@@ -162,7 +162,7 @@ before you submit a pull request:
 
       #### Additional information
       <Any additional information you think is important>
-      
+
 
 Coding Guidelines
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description="A package to implement and extend the methods desribed in 'A General Approach to Progressive Learning'",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
-    url="https://github.com/neurodata/progressive-learning/",
+    url="https://github.com/neurodata/ProgLearn/",
     license="MIT",
     classifiers=[
         "Intended Audience :: Science/Research",


### PR DESCRIPTION

<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Part of #138 
#### Type of change
<!--Bug, Documentation, Feature Request-->
Documentation
#### What does this implement/fix?
<!--Please explain your changes.-->
Update all the urls in documentation to direct to correct repo paths
#### Additional information
<!--Any additional information you think is important.-->
None

@levinwil @jdey4 