### PR TITLE
create CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+proglearn.neurodata.io


### PR DESCRIPTION
allows netlify to host on this site URL which we own under the neurodata.io domain.