### PR TITLE
Remove requirements redundancy and include package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-keras>=2.3.1
-tensorflow>=1.19.0
-scikit-learn>=0.22.0
-scipy==1.4.1
-numpy<1.19
-joblib>=0.14.1
+keras >= 2.3.1
+tensorflow >= 1.19.0
+scikit-learn >= 0.22.0
+scipy == 1.4.1
+numpy < 1.19
+joblib >= 0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-keras >= 2.3.1
-tensorflow >= 1.19.0
-scikit-learn >= 0.22.0
-scipy == 1.4.1
-numpy < 1.19
-joblib >= 0.14.1
+keras>=2.3.1
+tensorflow>=1.19.0
+scikit-learn>=0.22.0
+scipy==1.4.1
+numpy<1.19
+joblib>=0.14.1

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,6 @@
 from setuptools import setup, find_packages
 import os
 
-requirements = [
-    "keras",
-    "tensorflow ",
-    "scikit-learn",
-    "numpy",
-    "joblib",
-]
-
 # Find mgc version.
 PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
 for line in open(os.path.join(PROJECT_PATH, "proglearn", "__init__.py")):
@@ -17,6 +9,11 @@ for line in open(os.path.join(PROJECT_PATH, "proglearn", "__init__.py")):
 
 with open("README.md", mode="r", encoding = "utf8") as f:
     LONG_DESCRIPTION = f.read()
+
+REQUIREMENTS = []
+for line in open("requirements.txt", mode="r", encoding = "utf8"):
+    package = line.split()[0]
+    REQUIREMENTS.append(package)
 
 setup(
     name="proglearn",
@@ -38,7 +35,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7"
     ],
-    install_requires=requirements,
+    install_requires=REQUIREMENTS,
     packages=find_packages(exclude=["tests", "tests.*", "tests/*"]),
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,8 @@ for line in open(os.path.join(PROJECT_PATH, "proglearn", "__init__.py")):
 with open("README.md", mode="r", encoding = "utf8") as f:
     LONG_DESCRIPTION = f.read()
 
-REQUIREMENTS = []
-for line in open("requirements.txt", mode="r", encoding = "utf8"):
-    package = line.split()[0]
-    REQUIREMENTS.append(package)
+with open("requirements.txt", mode="r", encoding = "utf8") as f:
+    REQUIREMENTS = f.read()
 
 setup(
     name="proglearn",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
close #265 @jdey4 @levinwil 
#### Type of change
<!--Bug, Documentation, Feature Request-->
Documentation 
#### What does this implement/fix?
<!--Please explain your changes.-->
Remove the simplified requirement list from `setup.py` and let it read from `requirements.txt`.
#### Additional information
<!--Any additional information you think is important.-->
- `requires.txt` generated in `proglearn.egg-info` was the same as `requirements.txt`
- Tested in an empty virtual environment and `pip install proglearn` command showed all requirements satisfied.
- `pip list` command screenshots before and after:
<img width="292" alt="Screen Shot 2020-10-17 at 15 04 34" src="https://user-images.githubusercontent.com/20309845/96351559-02d82280-1071-11eb-8443-bb0e97b45842.png">
<img width="292" alt="Screen Shot 2020-10-17 at 14 59 37" src="https://user-images.githubusercontent.com/20309845/96351475-5f870d80-1070-11eb-989a-05f69d7dba26.png">
