### PR TITLE
forest.py line 237 change max_depth to self.max_depth

### DIFF
--- a/proglearn/forest.py
+++ b/proglearn/forest.py
@@ -234,7 +234,7 @@ class UncertaintyForest:
         self.lf = LifelongClassificationForest(
             n_estimators=self.n_estimators,
             default_finite_sample_correction=self.finite_sample_correction,
-            default_max_depth=max_depth,
+            default_max_depth=self.max_depth,
         )
         self.lf.add_task(X, y, task_id=0)
         return self


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
This is a new issue discovered 10/18 by @bstraus1 and @EYezerets 

#### Type of change
Correction to variable set.

#### What does this implement/fix?
max_depth error: Line 237 in forest.py had to be changed to say self.max_depth.

#### Additional information
This error previously prevented me from running uncertaintyforest_fig1.py on my local machine.