### PR TITLE
Fix {network, forest}.py default overloading

### DIFF
--- a/proglearn/forest.py
+++ b/proglearn/forest.py
@@ -87,16 +87,16 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         task_id : obj, default=None
             The id corresponding to the task being added.
 
-        tree_construction_proportion : int, default='default'
+        tree_construction_proportion : int or str, default='default'
             The proportions of the input data set aside to train each decision
             tree. The remainder of the data is used to fill in voting posteriors.
             The default is used if 'default' is provided.
 
-        finite_sample_correction : bool, default='default'
+        finite_sample_correction : bool or str, default='default'
             Boolean indicating whether this learner will have finite sample correction.
             The default is used if 'default' is provided.
 
-        max_depth : int, default='default'
+        max_depth : int or str, default='default'
             The maximum depth of a tree in the Lifelong Classification Forest.
             The default is used if 'default' is provided.
 
@@ -149,7 +149,7 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         transformer_id : obj, default=None
             The id corresponding to the transformer being added.
 
-        max_depth : int, default='default'
+        max_depth : int or str, default='default'
             The maximum depth of a tree in the UncertaintyForest.
             The default is used if 'default' is provided.
 

--- a/proglearn/forest.py
+++ b/proglearn/forest.py
@@ -65,9 +65,9 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         X,
         y,
         task_id=None,
-        tree_construction_proportion=None,
-        finite_sample_correction=None,
-        max_depth=None,
+        tree_construction_proportion='default',
+        finite_sample_correction='default',
+        max_depth='default',
     ):
         """
         adds a task with id task_id, max tree depth max_depth, given input data matrix X
@@ -87,29 +87,29 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         task_id : obj, default=None
             The id corresponding to the task being added.
 
-        tree_construction_proportion : int, default=None
+        tree_construction_proportion : int, default='default'
             The proportions of the input data set aside to train each decision
             tree. The remainder of the data is used to fill in voting posteriors.
-            The default is used if 'None' is provided.
+            The default is used if 'default' is provided.
 
-        finite_sample_correction : bool, default=False
+        finite_sample_correction : bool, default='default'
             Boolean indicating whether this learner will have finite sample correction.
-            The default is used if 'None' is provided.
+            The default is used if 'default' is provided.
 
-        max_depth : int, default=30
+        max_depth : int, default='default'
             The maximum depth of a tree in the Lifelong Classification Forest.
-            The default is used if 'None' is provided.
+            The default is used if 'default' is provided.
 
         Returns
         -------
         self : LifelongClassificationForest
             The object itself.
         """
-        if tree_construction_proportion is None:
+        if tree_construction_proportion == 'default':
             tree_construction_proportion = self.default_tree_construction_proportion
-        if finite_sample_correction is None:
+        if finite_sample_correction == 'default':
             finite_sample_correction = self.default_finite_sample_correction
-        if max_depth is None:
+        if max_depth == 'default':
             max_depth = self.default_max_depth
 
         self.pl_.add_task(
@@ -131,7 +131,7 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         )
         return self
 
-    def add_transformer(self, X, y, transformer_id=None, max_depth=None):
+    def add_transformer(self, X, y, transformer_id=None, max_depth='default'):
         """
         adds a transformer with id transformer_id and max tree depth max_depth, trained on
         given input data matrix, X, and output data matrix, y, to the Lifelong Classification Forest.
@@ -149,16 +149,16 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         transformer_id : obj, default=None
             The id corresponding to the transformer being added.
 
-        max_depth : int, default=30
+        max_depth : int, default='default'
             The maximum depth of a tree in the UncertaintyForest.
-            The default is used if 'None' is provided.
+            The default is used if 'default' is provided.
 
         Returns
         -------
         self : LifelongClassificationForest
             The object itself.
         """
-        if max_depth is None:
+        if max_depth == 'default':
             max_depth = self.default_max_depth
 
         self.pl_.add_transformer(

--- a/proglearn/forest.py
+++ b/proglearn/forest.py
@@ -65,9 +65,9 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         X,
         y,
         task_id=None,
-        tree_construction_proportion='default',
-        finite_sample_correction='default',
-        max_depth='default',
+        tree_construction_proportion="default",
+        finite_sample_correction="default",
+        max_depth="default",
     ):
         """
         adds a task with id task_id, max tree depth max_depth, given input data matrix X
@@ -105,11 +105,11 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         self : LifelongClassificationForest
             The object itself.
         """
-        if tree_construction_proportion == 'default':
+        if tree_construction_proportion == "default":
             tree_construction_proportion = self.default_tree_construction_proportion
-        if finite_sample_correction == 'default':
+        if finite_sample_correction == "default":
             finite_sample_correction = self.default_finite_sample_correction
-        if max_depth == 'default':
+        if max_depth == "default":
             max_depth = self.default_max_depth
 
         self.pl_.add_task(
@@ -131,7 +131,7 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         )
         return self
 
-    def add_transformer(self, X, y, transformer_id=None, max_depth='default'):
+    def add_transformer(self, X, y, transformer_id=None, max_depth="default"):
         """
         adds a transformer with id transformer_id and max tree depth max_depth, trained on
         given input data matrix, X, and output data matrix, y, to the Lifelong Classification Forest.
@@ -158,7 +158,7 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         self : LifelongClassificationForest
             The object itself.
         """
-        if max_depth == 'default':
+        if max_depth == "default":
             max_depth = self.default_max_depth
 
         self.pl_.add_transformer(

--- a/proglearn/network.py
+++ b/proglearn/network.py
@@ -111,7 +111,7 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
         task_id: obj
             The id corresponding to the task being added.
 
-        transformer_voter_decider_split: ndarray, default='default'
+        transformer_voter_decider_split: ndarray or str, default='default'
             1D array of length 3 corresponding to the proportions of data used to train the
             transformer(s) corresponding to the task_id, to train the voter(s) from the
             transformer(s) to the task_id, and to train the decider for task_id, respectively.

--- a/proglearn/network.py
+++ b/proglearn/network.py
@@ -95,7 +95,7 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
             default_decider_kwargs={},
         )
 
-    def add_task(self, X, y, task_id=None, transformer_voter_decider_split=None):
+    def add_task(self, X, y, task_id=None, transformer_voter_decider_split='default'):
         """
         adds a task with id task_id, given input data matrix X
         and output data matrix y, to the Lifelong Classification Network
@@ -111,18 +111,18 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
         task_id: obj
             The id corresponding to the task being added.
 
-        transformer_voter_decider_split: ndarray, default=None
+        transformer_voter_decider_split: ndarray, default='default'
             1D array of length 3 corresponding to the proportions of data used to train the
             transformer(s) corresponding to the task_id, to train the voter(s) from the
             transformer(s) to the task_id, and to train the decider for task_id, respectively.
-            The default is used if 'None' is provided.
+            The default is used if 'default' is provided.
 
         Returns
         -------
         self : LifelongClassificationNetwork
             The object itself.
         """
-        if transformer_voter_decider_split is None:
+        if transformer_voter_decider_split == 'default':
             transformer_voter_decider_split = (
                 self.default_transformer_voter_decider_split
             )

--- a/proglearn/network.py
+++ b/proglearn/network.py
@@ -95,7 +95,7 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
             default_decider_kwargs={},
         )
 
-    def add_task(self, X, y, task_id=None, transformer_voter_decider_split='default'):
+    def add_task(self, X, y, task_id=None, transformer_voter_decider_split="default"):
         """
         adds a task with id task_id, given input data matrix X
         and output data matrix y, to the Lifelong Classification Network
@@ -122,7 +122,7 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
         self : LifelongClassificationNetwork
             The object itself.
         """
-        if transformer_voter_decider_split == 'default':
+        if transformer_voter_decider_split == "default":
             transformer_voter_decider_split = (
                 self.default_transformer_voter_decider_split
             )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes Issue #322 

#### Type of change
<!--Bug, Documentation, Feature Request-->
Bug

#### What does this implement/fix?
<!--Please explain your changes.-->
Previously, we used None to instruct the usage of default parameters when calling 'add_{task, transformer}'. But, this has undesirable effects, such as the inability to add a new forest which trains to purity (unless the default value for the LLCF is None, which is not all the time). As such, we now use the string 'default' to indicate the usage of default parameters.

#### Additional information
<!--Any additional information you think is important.-->