### PR TITLE
transformer_voter_decider_split amendment to network_construction_proportion

### DIFF
--- a/proglearn/network.py
+++ b/proglearn/network.py
@@ -38,11 +38,10 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
         Boolean indicating the production of detailed logging information during training of the
         network.
 
-    default_transformer_voter_decider_split: ndarray
-            1D array of length 3 corresponding to the proportions of data used to train the
-            transformer(s) corresponding to the task_id, to train the voter(s) from the
-            transformer(s) to the task_id, and to train the decider for task_id, respectively.
-            This will be used if it isn't provided in add_task.
+    default_network_construction_proportion: float, default = 0.67
+        The proportions of the input data set aside to train each network. The remainder of the 
+        data is used to fill in voting posteriors. This is used if 'tree_construction_proportion' 
+        is not fed to add_task.
 
     Attributes
     ----------
@@ -59,7 +58,7 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
         epochs=100,
         batch_size=32,
         verbose=False,
-        default_transformer_voter_decider_split=[0.67, 0.33, 0],
+        default_network_construction_proportion=0.67,
     ):
         self.network = network
         self.loss = loss
@@ -67,8 +66,8 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
         self.optimizer = optimizer
         self.verbose = verbose
         self.batch_size = batch_size
-        self.default_transformer_voter_decider_split = (
-            default_transformer_voter_decider_split
+        self.default_network_construction_proportion = (
+            default_network_construction_proportion
         )
 
         # Set transformer network hyperparameters.
@@ -95,7 +94,7 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
             default_decider_kwargs={},
         )
 
-    def add_task(self, X, y, task_id=None, transformer_voter_decider_split="default"):
+    def add_task(self, X, y, task_id=None, network_construction_proportion="default"):
         """
         adds a task with id task_id, given input data matrix X
         and output data matrix y, to the Lifelong Classification Network
@@ -111,27 +110,25 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
         task_id: obj
             The id corresponding to the task being added.
 
-        transformer_voter_decider_split: ndarray or str, default='default'
-            1D array of length 3 corresponding to the proportions of data used to train the
-            transformer(s) corresponding to the task_id, to train the voter(s) from the
-            transformer(s) to the task_id, and to train the decider for task_id, respectively.
-            The default is used if 'default' is provided.
+        network_construction_proportion: float or str, default='default'
+            The proportions of the input data set aside to train each network. The remainder of the 
+            data is used to fill in voting posteriors. The default is used if 'default' is provided.
 
         Returns
         -------
         self : LifelongClassificationNetwork
             The object itself.
         """
-        if transformer_voter_decider_split == "default":
-            transformer_voter_decider_split = (
-                self.default_transformer_voter_decider_split
+        if network_construction_proportion == "default":
+            network_construction_proportion = (
+                self.network_construction_proportion
             )
 
         return self.pl_.add_task(
             X,
             y,
             task_id=task_id,
-            transformer_voter_decider_split=transformer_voter_decider_split,
+            transformer_voter_decider_split=[network_construction_proportion, 1 - network_construction_proportion, 0],
             decider_kwargs={"classes": np.unique(y)},
             voter_kwargs={"classes": np.unique(y)},
         )

--- a/proglearn/network.py
+++ b/proglearn/network.py
@@ -39,8 +39,8 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
         network.
 
     default_network_construction_proportion: float, default = 0.67
-        The proportions of the input data set aside to train each network. The remainder of the 
-        data is used to fill in voting posteriors. This is used if 'tree_construction_proportion' 
+        The proportions of the input data set aside to train each network. The remainder of the
+        data is used to fill in voting posteriors. This is used if 'tree_construction_proportion'
         is not fed to add_task.
 
     Attributes
@@ -111,7 +111,7 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
             The id corresponding to the task being added.
 
         network_construction_proportion: float or str, default='default'
-            The proportions of the input data set aside to train each network. The remainder of the 
+            The proportions of the input data set aside to train each network. The remainder of the
             data is used to fill in voting posteriors. The default is used if 'default' is provided.
 
         Returns
@@ -120,15 +120,17 @@ class LifelongClassificationNetwork(ClassificationProgressiveLearner):
             The object itself.
         """
         if network_construction_proportion == "default":
-            network_construction_proportion = (
-                self.network_construction_proportion
-            )
+            network_construction_proportion = self.network_construction_proportion
 
         return self.pl_.add_task(
             X,
             y,
             task_id=task_id,
-            transformer_voter_decider_split=[network_construction_proportion, 1 - network_construction_proportion, 0],
+            transformer_voter_decider_split=[
+                network_construction_proportion,
+                1 - network_construction_proportion,
+                0,
+            ],
             decider_kwargs={"classes": np.unique(y)},
             voter_kwargs={"classes": np.unique(y)},
         )

--- a/proglearn/tests/test_network.py
+++ b/proglearn/tests/test_network.py
@@ -40,6 +40,6 @@ class TestLifelongClassificationNetwork:
         # decider
         assert len(l2n.pl_.default_decider_kwargs) == 0
 
-    def test_correct_default_transformer_voter_decider_split(self):
+    def test_correct_default_network_construction_proportion(self):
         l2n = LifelongClassificationNetwork(keras.Sequential())
-        assert l2n.default_transformer_voter_decider_split == [0.67, 0.33, 0]
+        assert l2n.default_network_construction_proportion == 0.67


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #331 
#### Type of change
<!--Bug, Documentation, Feature Request-->
Feature Request
#### What does this implement/fix?
<!--Please explain your changes.-->
We previously used transformer_voter_decider_split as an argument to add_task in network.py. This is unnecessary, as we don't have any decider data. So, I changed it to network_construction_proportion: the network is trained on network_construction_proportion of the data and the voters are trained on 1 - network_construction_proportion of the data.
#### Additional information
<!--Any additional information you think is important.-->