### PR TITLE
Fixed bug in missing_label_indices indexing by value instead of index

### DIFF
--- a/proglearn/voters.py
+++ b/proglearn/voters.py
@@ -61,6 +61,7 @@ class TreeClassificationVoter(BaseClassificationVoter):
         """
         check_classification_targets(y)
 
+        _, y = np.unique(y, return_inverse=True)
         num_fit_classes = len(np.unique(y))
         self.missing_label_indices_ = []
 
@@ -146,7 +147,7 @@ class TreeClassificationVoter(BaseClassificationVoter):
         NotFittedError
             When the model is not fitted.
         """
-        return np.argmax(self.predict_proba(X), axis=1)
+        return self.classes[np.argmax(self.predict_proba(X), axis=1)]
 
     def _finite_sample_correction(
         self, posteriors, num_points_in_partition, num_classes


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### Type of change
<!--Bug, Documentation, Feature Request-->
Bugfix

#### What does this implement/fix?
<!--Please explain your changes.-->
Addition of array of zeros when considering missing labels fixed: index by missing label indices instead of missing label values

#### Additional information
<!--Any additional information you think is important.-->