### PR TITLE
Fix missing_label_indices label matching & posterior lengths

### DIFF
--- a/proglearn/voters.py
+++ b/proglearn/voters.py
@@ -61,18 +61,17 @@ class TreeClassificationVoter(BaseClassificationVoter):
         """
         check_classification_targets(y)
 
-        _, y_idxs = np.unique(y, return_inverse=True)
-        num_fit_classes = len(np.unique(y_idxs))
+        num_fit_classes = len(np.unique(y))
         self.missing_label_indices_ = []
 
         if np.asarray(self.classes).size != 0 and num_fit_classes < len(self.classes):
-            for label in self.classes:
-                if label not in np.unique(y_idxs):
-                    self.missing_label_indices_.append(label)
+            for idx, label in enumerate(self.classes):
+                if label not in np.unique(y):
+                    self.missing_label_indices_.append(idx)
 
         num_classes = num_fit_classes + len(self.missing_label_indices_)
 
-        self.uniform_posterior_ = np.ones(num_classes) / num_classes
+        self.uniform_posterior_ = np.ones(num_fit_classes) / num_fit_classes
 
         self.leaf_to_posterior_ = {}
 

--- a/proglearn/voters.py
+++ b/proglearn/voters.py
@@ -71,7 +71,7 @@ class TreeClassificationVoter(BaseClassificationVoter):
 
         num_classes = num_fit_classes + len(self.missing_label_indices_)
 
-        self.uniform_posterior_ = np.ones(num_fit_classes) / num_fit_classes
+        self.uniform_posterior_ = np.ones(num_classes) / num_classes
 
         self.leaf_to_posterior_ = {}
 
@@ -240,9 +240,9 @@ class KNNClassificationVoter(BaseClassificationVoter):
         self.missing_label_indices_ = []
 
         if np.asarray(self.classes).size != 0 and num_classes < len(self.classes):
-            for label in self.classes:
+            for idx, label in enumerate(self.classes):
                 if label not in np.unique(y):
-                    self.missing_label_indices_.append(label)
+                    self.missing_label_indices_.append(idx)
 
         return self
 
@@ -295,4 +295,4 @@ class KNNClassificationVoter(BaseClassificationVoter):
         NotFittedError
             When the model is not fitted.
         """
-        return np.argmax(self.predict_proba(X), axis=1)
+        return self.classes[np.argmax(self.predict_proba(X), axis=1)]

--- a/proglearn/voters.py
+++ b/proglearn/voters.py
@@ -61,13 +61,13 @@ class TreeClassificationVoter(BaseClassificationVoter):
         """
         check_classification_targets(y)
 
-        _, y = np.unique(y, return_inverse=True)
-        num_fit_classes = len(np.unique(y))
+        _, y_idxs = np.unique(y, return_inverse=True)
+        num_fit_classes = len(np.unique(y_idxs))
         self.missing_label_indices_ = []
 
         if np.asarray(self.classes).size != 0 and num_fit_classes < len(self.classes):
             for label in self.classes:
-                if label not in np.unique(y):
+                if label not in np.unique(y_idxs):
                     self.missing_label_indices_.append(label)
 
         num_classes = num_fit_classes + len(self.missing_label_indices_)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Follow-up to fix in #341 

#### Type of change
<!--Bug, Documentation, Feature Request-->
Bugfix

#### What does this implement/fix?
<!--Please explain your changes.-->
Made a few more changes to...
1. Fix the matching of self.classes for finding the missing_class_labels (changing y to the indices at the beginning results in it matching the classes to the indices and not the label) 
2. Make sure the leaf posteriors and uniform posteriors are the same length

#### Additional information
<!--Any additional information you think is important.-->
My bad for not catching this before submitting the first PR!