### PR TITLE
Simplify the title for label shuffle experiment

### DIFF
--- a/docs/tutorials/label_shuffle_exp.ipynb
+++ b/docs/tutorials/label_shuffle_exp.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Label Shuffle Experiment for Progressive Learning\n",
+    "# Label Shuffle Experiment\n",
     "\n",
     "The progressive learning package utilizes representation ensembling algorithms to sequentially learn a representation for each task and ensemble both old and new representations for all future decisions. \n",
     "\n",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#75 
#### Type of change
<!--Bug, Documentation, Feature Request-->
Documentation
#### What does this implement/fix?
<!--Please explain your changes.-->
Simplify the title for label shuffle experiment by removing the "for Progressive Learning" part.
#### Additional information
<!--Any additional information you think is important.-->
None