### PR TITLE
update progressive_learner.py to fix the decider data splitting

### DIFF
--- a/proglearn/progressive_learner.py
+++ b/proglearn/progressive_learner.py
@@ -408,8 +408,9 @@ class ProgressiveLearner(BaseProgressiveLearner):
         X, y = self.task_id_to_X[task_id], self.task_id_to_y[task_id]
 
         self.task_id_to_decider[task_id] = decider_class(**decider_kwargs)
+        decider_idx = self.task_id_to_decider_idx[task_id]
         self.task_id_to_decider[task_id].fit(
-            X, y, transformer_id_to_transformers, transformer_id_to_voters
+            X[decider_idx], y[decider_idx], transformer_id_to_transformers, transformer_id_to_voters
         )
 
         self.task_id_to_decider_class[task_id] = decider_class

--- a/proglearn/progressive_learner.py
+++ b/proglearn/progressive_learner.py
@@ -410,7 +410,10 @@ class ProgressiveLearner(BaseProgressiveLearner):
         self.task_id_to_decider[task_id] = decider_class(**decider_kwargs)
         decider_idx = self.task_id_to_decider_idx[task_id]
         self.task_id_to_decider[task_id].fit(
-            X[decider_idx], y[decider_idx], transformer_id_to_transformers, transformer_id_to_voters
+            X[decider_idx],
+            y[decider_idx],
+            transformer_id_to_transformers,
+            transformer_id_to_voters,
         )
 
         self.task_id_to_decider_class[task_id] = decider_class


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes issue #385

#### Type of change
<!--Bug, Documentation, Feature Request-->
Fixes bug with decider data splitting.

#### What does this implement/fix?
<!--Please explain your changes.-->
Previously, the decider is fitted with all data as it is not indexed by the `decider_idx`.
With this fix, it uses the amount of splitted data that it has access to.

#### Additional information
<!--Any additional information you think is important.-->
N/A