### PR TITLE
Fix kwargs in forest

### DIFF
--- a/proglearn/forest.py
+++ b/proglearn/forest.py
@@ -168,7 +168,7 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
             }
 
         else:
-            transformer_kwargs = ({"kwargs": {"max_depth": max_depth}},)
+            transformer_kwargs = {"kwargs": {"max_depth": max_depth}}
 
         X, y = check_X_y(X, y)
         return self.pl_.add_task(

--- a/proglearn/forest.py
+++ b/proglearn/forest.py
@@ -218,7 +218,7 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
             The number of trees used for the given task.
 
         max_depth : int or str, default='default'
-            The maximum depth of a tree in the UncertaintyForest.
+            The maximum depth of a tree in the Lifelong Classification Forest.
             The default is used if 'default' is provided.
 
         Returns


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None
#### Type of change
<!--Bug, Documentation, Feature Request-->
Bug & Documentation
#### What does this implement/fix?
<!--Please explain your changes.-->

- Fix kwargs format in `LifelongClassificationForest` for non-oblique trees
- Fix class name in documentation

#### Additional information
<!--Any additional information you think is important.-->
Credits to @EYezerets for pointing out the bug!