### PR TITLE
Make the array-ness of self.classes explicit

### DIFF
--- a/proglearn/voters.py
+++ b/proglearn/voters.py
@@ -41,7 +41,7 @@ class TreeClassificationVoter(BaseClassificationVoter):
 
     def __init__(self, kappa=np.inf, classes=[]):
         self.kappa = kappa
-        self.classes = classes
+        self.classes = np.asarray(classes)
 
     def fit(self, X, y):
         """
@@ -64,7 +64,7 @@ class TreeClassificationVoter(BaseClassificationVoter):
         num_fit_classes = len(np.unique(y))
         self.missing_label_indices_ = []
 
-        if np.asarray(self.classes).size != 0 and num_fit_classes < len(self.classes):
+        if self.classes.size != 0 and num_fit_classes < len(self.classes):
             for idx, label in enumerate(self.classes):
                 if label not in np.unique(y):
                     self.missing_label_indices_.append(idx)
@@ -141,7 +141,7 @@ class TreeClassificationVoter(BaseClassificationVoter):
         NotFittedError
             When the model is not fitted.
         """
-        return np.asarray(self.classes)[np.argmax(self.predict_proba(X), axis=1)]
+        return self.classes[np.argmax(self.predict_proba(X), axis=1)]
 
     def _finite_sample_correction(self, posteriors, num_points_in_partition, kappa):
         """
@@ -232,7 +232,7 @@ class KNNClassificationVoter(BaseClassificationVoter):
         num_classes = len(np.unique(y))
         self.missing_label_indices_ = []
 
-        if np.asarray(self.classes).size != 0 and num_classes < len(self.classes):
+        if self.classes.size != 0 and num_classes < len(self.classes):
             for idx, label in enumerate(self.classes):
                 if label not in np.unique(y):
                     self.missing_label_indices_.append(idx)
@@ -288,4 +288,4 @@ class KNNClassificationVoter(BaseClassificationVoter):
         NotFittedError
             When the model is not fitted.
         """
-        return np.asarray(self.classes)[np.argmax(self.predict_proba(X), axis=1)]
+        return self.classes[np.argmax(self.predict_proba(X), axis=1)]

--- a/proglearn/voters.py
+++ b/proglearn/voters.py
@@ -141,7 +141,7 @@ class TreeClassificationVoter(BaseClassificationVoter):
         NotFittedError
             When the model is not fitted.
         """
-        return self.classes[np.argmax(self.predict_proba(X), axis=1)]
+        return np.asarray(self.classes)[np.argmax(self.predict_proba(X), axis=1)]
 
     def _finite_sample_correction(self, posteriors, num_points_in_partition, kappa):
         """
@@ -288,4 +288,4 @@ class KNNClassificationVoter(BaseClassificationVoter):
         NotFittedError
             When the model is not fitted.
         """
-        return self.classes[np.argmax(self.predict_proba(X), axis=1)]
+        return np.asarray(self.classes)[np.argmax(self.predict_proba(X), axis=1)]

--- a/proglearn/voters.py
+++ b/proglearn/voters.py
@@ -206,7 +206,7 @@ class KNNClassificationVoter(BaseClassificationVoter):
     def __init__(self, k=None, kwargs={}, classes=[]):
         self.k = k
         self.kwargs = kwargs
-        self.classes = classes
+        self.classes = np.asarray(classes)
 
     def fit(self, X, y):
         """


### PR DESCRIPTION
Indexing into a list using an array of integers does not work and for some reason in my use case that's what self.classes is. This simply makes the array-ness of self.classes explicit.

<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### Type of change
<!--Bug, Documentation, Feature Request-->
Bug 

#### What does this implement/fix?
<!--Please explain your changes.-->
Ensures that voter output can be indexed, even if the `classes` provided in the class are not numpy arrays

#### Additional information
<!--Any additional information you think is important.-->