### PR TITLE
Remove numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ keras>=2.3.1
 tensorflow>=1.19.0
 scikit-learn>=0.22.0
 scipy==1.4.1
-numpy<1.19
 joblib>=0.14.1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Close #402 
#### Type of change
<!--Bug, Documentation, Feature Request-->
Bug
#### What does this implement/fix?
<!--Please explain your changes.-->
Resolve requirement conflicts on `numpy` version
#### Additional information
<!--Any additional information you think is important.-->
As 4 dependencies of `proglearn` already specified `numpy` requirements, having it as an additional entry seems repetitive.