### PR TITLE
Fix incorrect array dimensions in docstring

### DIFF
--- a/proglearn/transformers.py
+++ b/proglearn/transformers.py
@@ -389,10 +389,10 @@ class ObliqueSplitter:
 
         Returns
         -------
-        proj_mat : {ndarray, sparse matrix} of shape (n_samples, n_features)
+        proj_mat : {ndarray, sparse matrix} of shape (self.proj_dims, n_features)
             The generated sparse random matrix.
-        proj_mat : {ndarray, sparse matrix} of shape (n_samples, n_features)
-            Projected matrix.
+        proj_X : {ndarray, sparse matrix} of shape (n_samples, self.proj_dims)
+            Projected input data matrix.
         """
 
         proj_mat = SparseRandomProjection(
@@ -406,21 +406,21 @@ class ObliqueSplitter:
 
     def leaf_label_proba(self, idx):
         """
-         Finds the most common label and probability of this label from the samples at
-         the leaf node for which this is used on.
+        Finds the most common label and probability of this label from the samples at
+        the leaf node for which this is used on.
 
-         Parameters
-         ----------
-         idx : array of shape [n_samples]
-             The indices of the samples that are at the leaf node for which the label
-             and probability need to be found.
+        Parameters
+        ----------
+        idx : array of shape [n_samples]
+            The indices of the samples that are at the leaf node for which the label
+            and probability need to be found.
 
-         Returns
-         -------
+        Returns
+        -------
         label : int
-             The label for any sample that is predicted to be at this node.
-         proba : float
-             The probability of the predicted sample to have this node's label.
+            The label for any sample that is predicted to be at this node.
+        proba : float
+            The probability of the predicted sample to have this node's label.
         """
 
         samples = self.y[idx]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### Type of change
Documentation

#### What does this implement/fix?
<!--Please explain your changes.-->
Docstring for the oblique splitter listed incorrect dimensions for the projection matrix and the projected data matrix. 

Also docstrings in an adjacent function had weird spacing, fixed.

#### Additional information
<!--Any additional information you think is important.-->