### PR TITLE
Parallelize Gini impurity calculation for oblique splitter

### DIFF
--- a/proglearn/tests/test_transformer.py
+++ b/proglearn/tests/test_transformer.py
@@ -46,6 +46,8 @@ class TestObliqueSplitter:
         random_state = 0
         rng.seed(random_state)
 
+        workers = -1
+
         X = rng.rand(100, 100)
         y = np.zeros(100)
 
@@ -62,7 +64,7 @@ class TestObliqueSplitter:
         n_sample_inds = [10, 20, 40, 60, 80]
 
         for pd in proj_dims:
-            splitter = ObliqueSplitter(X, y, pd, density, random_state)
+            splitter = ObliqueSplitter(X, y, pd, density, random_state, workers)
 
             for i in range(len(n_sample_inds)):
                 si = sample_inds[i]
@@ -77,13 +79,15 @@ class TestObliqueSplitter:
         random_state = 0
         rng.seed(random_state)
 
+        workers = -1
+
         X = rng.rand(11, 11)
 
         density = 0.5
         proj_dims = 5
 
         y = np.array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
-        splitter = ObliqueSplitter(X, y, proj_dims, density, random_state)
+        splitter = ObliqueSplitter(X, y, proj_dims, density, random_state, workers)
 
         score = splitter.score(y, 6)
         assert 0 == score
@@ -96,6 +100,8 @@ class TestObliqueSplitter:
         random_state = 0
         rng.seed(random_state)
 
+        workers = -1
+
         X = rng.rand(100, 100)
 
         density = 0.5
@@ -106,7 +112,7 @@ class TestObliqueSplitter:
             for j in range(10):
                 y[10 * i + j] = i
 
-        splitter = ObliqueSplitter(X, y, proj_dims, density, random_state)
+        splitter = ObliqueSplitter(X, y, proj_dims, density, random_state, workers)
 
         # Impurity of one thing should be 0
         impurity = splitter.impurity([0])
@@ -129,6 +135,8 @@ class TestObliqueSplitter:
         random_state = 0
         rng.seed(random_state)
 
+        workers = -1
+
         X = rng.rand(100, 100)
 
         density = 0.5
@@ -139,7 +147,7 @@ class TestObliqueSplitter:
             for j in range(10):
                 y[10 * i + j] = i
 
-        splitter = ObliqueSplitter(X, y, proj_dims, density, random_state)
+        splitter = ObliqueSplitter(X, y, proj_dims, density, random_state, workers)
 
         split_info = splitter.split(np.array([i for i in range(100)]))
 

--- a/proglearn/transformers.py
+++ b/proglearn/transformers.py
@@ -357,6 +357,8 @@ class ObliqueSplitter:
         node.
     score(y_sort, t)
         Finds the Gini impurity for a split.
+    _score(self, proj_X, y_sample, i, j)
+        Handles array indexing before calculating Gini impurity.
     impurity(idx)
         Finds the impurity for a certain set of samples.
     split(sample_inds)
@@ -472,6 +474,38 @@ class ObliqueSplitter:
             n_right / self.n_samples
         ) * right_gini
         return gini
+
+    def _score(self, proj_X, y_sample, i, j):
+        """
+        Handles array indexing before calculating Gini impurity
+
+        Parameters
+        ----------
+        proj_X : {ndarray, sparse matrix} of shape (n_samples, self.proj_dims)
+            Projected input data matrix.
+        y_sample : array of shape [n_samples]
+            Labels for sample of data.
+        i : float
+            The threshold determining where to split y_sort.
+        j : float
+            The projection dimension to consider.
+
+        Returns
+        -------
+        gini : float
+            The Gini impurity of the split.
+        i : float
+            The threshold determining where to split y_sort.
+        j : float
+            The projection dimension to consider.
+        """
+        # Sort labels by the jth feature
+        idx = np.argsort(proj_X[:, j])
+        y_sort = y_sample[idx]
+
+        gini = self.score(y_sort, i)
+
+        return gini, i, j
 
     # Returns impurity for a group of examples
     # expects idx not None

--- a/proglearn/transformers.py
+++ b/proglearn/transformers.py
@@ -343,7 +343,7 @@ class ObliqueSplitter:
     random_state : int
         Controls the pseudo random number generator used to generate the projection matrix.
     workers : int
-        The number of cores to parallelize the p-value computation over.
+        The number of cores to parallelize the calculation of Gini impurity.
         Supply -1 to use all cores available to the Process.
 
     Methods
@@ -984,7 +984,7 @@ class ObliqueTreeClassifier(BaseEstimator):
     density : float
         Density estimate.
     workers : int, optional (default: -1)
-        The number of cores to parallelize the p-value computation over.
+        The number of cores to parallelize the calculation of Gini impurity.
         Supply -1 to use all cores available to the Process.
 
     Methods


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes #415 

#### Type of change
<!--Bug, Documentation, Feature Request-->
Feature Request

#### What does this implement/fix?
<!--Please explain your changes.-->
- Parallelizes calculation of Gini impurity for potential splits using `joblib`
- Adds `workers`, an argument for specifying number of cores to parallelize the calculation of Gini impurity

#### Additional information
<!--Any additional information you think is important.-->