### PR TITLE
working prototype

### DIFF
--- a/proglearn/forest.py
+++ b/proglearn/forest.py
@@ -35,6 +35,21 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         The maximum depth of a tree in the Lifelong Classification Forest.
         This is used if 'max_depth' is not fed to add_task.
 
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. ``-1`` means use all
+        processors.
+
+    max_samples : int or float, default=0.5
+        The number of samples to draw from X (without replacement) to train
+        each tree.
+        - If None, then draw `X.shape[0]` samples.
+        - If int, then draw `max_samples` samples.
+        - If float, then draw `max_samples * X.shape[0]` samples. Thus,
+          `max_samples` should be in the interval `(0, 1)`.
+
+        Note: The number of samples used to learn the tree will be further
+        reduced per the `tree_construction_proportion` value.
+
     Attributes
     ----------
     pl_ : ClassificationProgressiveLearner
@@ -48,11 +63,15 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         default_tree_construction_proportion=0.67,
         default_kappa=np.inf,
         default_max_depth=30,
+        max_samples=None,
+        n_jobs=None,
     ):
         self.default_n_estimators = default_n_estimators
         self.default_tree_construction_proportion = default_tree_construction_proportion
         self.default_kappa = default_kappa
         self.default_max_depth = default_max_depth
+        self.max_samples = max_samples
+        self.n_jobs = n_jobs
 
         self.pl_ = ClassificationProgressiveLearner(
             default_transformer_class=TreeClassificationTransformer,
@@ -61,6 +80,7 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
             default_voter_kwargs={"kappa": default_kappa},
             default_decider_class=SimpleArgmaxAverage,
             default_decider_kwargs={},
+            n_jobs=n_jobs,
         )
 
     def add_task(
@@ -72,6 +92,8 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         tree_construction_proportion="default",
         kappa="default",
         max_depth="default",
+        transformer_kwargs={},
+        max_samples=1.0,
     ):
         """
         adds a task with id task_id, max tree depth max_depth, given input data matrix X
@@ -103,15 +125,35 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
             The coefficient for finite sample correction.
             The default is used if 'default' is provided.
 
+        TODO prune max_depth into transformer_kwargs
         max_depth : int or str, default='default'
             The maximum depth of a tree in the Lifelong Classification Forest.
             The default is used if 'default' is provided.
+
+        transformer_kwargs : dict, default={}
+            Additional named arguments to be passed to the transformer.
+
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. ``-1`` means use all
+        processors.
+
+    max_samples : int or float, default=0.5
+        The number of samples to draw from X (without replacement) to train
+        each tree.
+        - If None, then draw `X.shape[0]` samples.
+        - If int, then draw `max_samples` samples.
+        - If float, then draw `max_samples * X.shape[0]` samples. Thus,
+          `max_samples` should be in the interval `(0, 1)`.
+
+        Note: The number of samples used to learn the tree will be further
+        reduced per the `tree_construction_proportion` value.
 
         Returns
         -------
         self : LifelongClassificationForest
             The object itself.
         """
+        # TODO get rid of defaults in favor of None
         if n_estimators == "default":
             n_estimators = self.default_n_estimators
         if tree_construction_proportion == "default":
@@ -121,18 +163,28 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
         if max_depth == "default":
             max_depth = self.default_max_depth
 
+        # TODO eliminate by subsuming max_depth
+        if not "fit_kwargs" in transformer_kwargs.keys():
+            transformer_kwargs["fit_kwargs"] = {}
+        transformer_kwargs["fit_kwargs"]["max_depth"] = max_depth
+
         X, y = check_X_y(X, y)
+        if isinstance(max_samples, int):
+            assert max_samples > 1
+            max_samples = min(1, max_samples / X.shape[0])
+        elif max_samples is None:
+            max_samples = 1.0
         return self.pl_.add_task(
             X,
             y,
             task_id=task_id,
             transformer_voter_decider_split=[
-                tree_construction_proportion,
-                1 - tree_construction_proportion,
+                tree_construction_proportion * max_samples,
+                (1 - tree_construction_proportion) * max_samples,
                 0,
             ],
             num_transformers=n_estimators,
-            transformer_kwargs={"kwargs": {"max_depth": max_depth}},
+            transformer_kwargs=transformer_kwargs,
             voter_kwargs={
                 "classes": np.unique(y),
                 "kappa": kappa,
@@ -232,7 +284,7 @@ class LifelongClassificationForest(ClassificationProgressiveLearner):
 
 class UncertaintyForest:
     """
-    A class used to represent an uncertainty forest.
+    A class used to represent an Uncertainty Forest.
 
     Parameters
     ----------
@@ -243,31 +295,95 @@ class UncertaintyForest:
         The coefficient for finite sample correction.
         If set to the default value, finite sample correction is not performed.
 
-    max_depth : int, default=30
-        The maximum depth of a tree in the UncertaintyForest
+    max_depth : int, default=None
+        The maximum depth of a tree in the UncertaintyForest.
 
-    tree_construction_proportion : float, default = 0.67
+    tree_construction_proportion : float, default=0.5
         The proportions of the input data set aside to train each decision
         tree. The remainder of the data is used to fill in voting posteriors.
 
+    max_features : {"auto", "sqrt", "log2"}, int or float, default="auto"
+        The number of features to consider when looking for the best split:
+        - If int, then consider `max_features` features at each split.
+        - If float, then `max_features` is a fraction and
+          `round(max_features * n_features)` features are considered at each
+          split.
+        - If "auto", then `max_features=sqrt(n_features)`.
+        - If "sqrt", then `max_features=sqrt(n_features)` (same as "auto").
+        - If "log2", then `max_features=log2(n_features)`.
+        - If None, then `max_features=n_features`.
+
+        Note: the search for a split does not stop until at least one
+        valid partition of the node samples is found, even if it requires to
+        effectively inspect more than ``max_features`` features.
+
+    poisson_sampler : boolean, default=True
+        To match the GRF theory [#1grf]_, if True, the number of features
+        considered at each tree are drawn from a poisson distribution with
+        mean equal to `max_features`.
+
+    n_jobs : int, default=1
+        The number of jobs to run in parallel. ``-1`` means use all
+        processors.
+
+    max_samples : int or float, default=0.5
+        The number of samples to draw from X (without replacement) to train
+        each tree.
+        - If None, then draw `X.shape[0]` samples.
+        - If int, then draw `max_samples` samples.
+        - If float, then draw `max_samples * X.shape[0]` samples. Thus,
+          `max_samples` should be in the interval `(0, 1)`.
+
+        Note: The number of samples used to learn the tree will be further
+        reduced per the `tree_construction_proportion` value.
+
+    tree_kwargs : dict, default={}
+        Named arguments to be passed to each
+        sklearn.tree.DecisionTreeClassifier tree used in the construction
+        of the forest in addition to the above parameters.
+
     Attributes
     ----------
+    estimators_ : list of sklearn.tree.DecisionTreeClassifier
+        The collection of fitted trees.
+
     lf_ : LifelongClassificationForest
         Internal LifelongClassificationForest used to train and make
         inference.
+
+    n_features_ : int
+        The number of features when `fit` is performed.
+
+    tree_kwargs_ : dict
+        Full set of keyword arguments passed to the Forest transformer.
+
+    References
+    ----------
+    .. [#1grf] Athey, Susan, Julie Tibshirani and Stefan Wager.
+    "Generalized Random Forests", Annals of Statistics, 2019.
     """
 
     def __init__(
         self,
         n_estimators=100,
         kappa=np.inf,
-        max_depth=30,
-        tree_construction_proportion=0.67,
+        max_depth=None,
+        tree_construction_proportion=0.5,
+        max_features="auto",
+        poisson_sampler=True,
+        max_samples=0.5,
+        n_jobs=None,
+        tree_kwargs={},
     ):
         self.n_estimators = n_estimators
         self.kappa = kappa
         self.max_depth = max_depth
         self.tree_construction_proportion = tree_construction_proportion
+        self.max_features = max_features
+        self.poisson_sampler = poisson_sampler
+        self.max_samples = max_samples
+        self.n_jobs = n_jobs
+        self.tree_kwargs = tree_kwargs
 
     def fit(self, X, y):
         """
@@ -286,6 +402,8 @@ class UncertaintyForest:
         self : UncertaintyForest
             The object itself.
         """
+        X, y = check_X_y(X, y)
+        self.n_features_ = X.shape[1]
         self.lf_ = LifelongClassificationForest(
             default_n_estimators=self.n_estimators,
             default_kappa=self.kappa,
@@ -293,8 +411,26 @@ class UncertaintyForest:
             default_tree_construction_proportion=self.tree_construction_proportion,
         )
 
-        X, y = check_X_y(X, y)
-        return self.lf_.add_task(X, y, task_id=0)
+        self.tree_kwargs_ = {
+            "fit_kwargs": self.tree_kwargs,
+            "max_features": self.max_features,
+            "poisson_sampler": self.poisson_sampler,
+        }
+        self.lf_.add_task(
+            X,
+            y,
+            task_id=0,
+            transformer_kwargs=self.tree_kwargs_,
+            max_samples=self.max_samples,
+        )
+
+        return self
+
+    @property
+    def estimators_(self):
+        if not hasattr(self, "lf_"):
+            raise AttributeError("Model has not been fitted. Please fit first.")
+        return [t.transformer_ for t in self.lf_.pl_.transformer_id_to_transformers[0]]
 
     def predict_proba(self, X):
         """
@@ -310,7 +446,10 @@ class UncertaintyForest:
         y_proba_hat : ndarray of shape [n_samples, n_classes]
             posteriors per example
         """
-        return self.lf_.predict_proba(check_array(X), 0)
+        X = check_array(X)
+        if not hasattr(self, "lf_"):
+            raise AttributeError("Model has not been fitted. Please fit first.")
+        return self.lf_.predict_proba(X, 0)
 
     def predict(self, X):
         """
@@ -326,4 +465,7 @@ class UncertaintyForest:
         y_hat : ndarray of shape [n_samples]
             predicted class label per example
         """
-        return self.lf_.predict(check_array(X), 0)
+        X = check_array(X)
+        if not hasattr(self, "lf_"):
+            raise AttributeError("Model has not been fitted. Please fit first.")
+        return self.lf_.predict(X, 0)

--- a/proglearn/tests/test_forest.py
+++ b/proglearn/tests/test_forest.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 import random
 
-from proglearn.forest import LifelongClassificationForest
+from proglearn.forest import LifelongClassificationForest, UncertaintyForest
 from proglearn.transformers import TreeClassificationTransformer
 from proglearn.voters import TreeClassificationVoter
 from proglearn.deciders import SimpleArgmaxAverage
@@ -47,3 +47,64 @@ class TestLifelongClassificationForest:
     def test_correct_true_initilization_finite_sample_correction(self):
         l2f = LifelongClassificationForest(default_kappa=np.inf)
         assert l2f.pl_.default_voter_kwargs == {"kappa": np.inf}
+
+
+# Test Uncertainty Forest
+
+
+def test_uf_accuracy():
+    uf = UncertaintyForest()
+    X = np.ones((20, 4))
+    X[10:] *= -1
+    y = [0] * 10 + [1] * 10
+    uf = uf.fit(X, y)
+    np.testing.assert_array_equal(uf.predict(X), y)
+
+
+@pytest.mark.parametrize("max_depth", [1, None])
+@pytest.mark.parametrize("max_features", [2, 0.5, "auto", "sqrt", "log2"])
+@pytest.mark.parametrize("poisson_sampler", [False, True])
+def test_decision_tree_params(max_depth, max_features, poisson_sampler):
+    uf = UncertaintyForest(
+        max_depth=max_depth, max_features=max_features, poisson_sampler=poisson_sampler
+    )
+    X = np.ones((12, 20))
+    X[6:] *= -1
+    y = [0] * 6 + [1] * 6
+    uf = uf.fit(X, y)
+
+    assert uf.n_estimators == len(uf.estimators_)
+    depths = [est.max_depth for est in uf.estimators_]
+    assert all(np.asarray(depths) == max_depth)
+
+    features = [est.max_features for est in uf.estimators_]
+    if poisson_sampler:
+        assert not all(np.asarray(features) == features[0])
+    else:
+        assert all(np.asarray(features) == max_features)
+
+
+def test_parallel_trees():
+    uf = UncertaintyForest(n_jobs=2)
+    X = np.random.normal(0, 1, (100, 2))
+    X[:50] *= -1
+    y = [0] * 50 + [1] * 50
+    uf = uf.fit(X, y)
+
+
+def test_max_samples():
+    max_samples_list = [8, 0.5, None]
+    depths = []
+    X = np.random.normal(0, 1, (100, 2))
+    X[:50] *= -1
+    y = [0, 1] * 50
+    for ms in max_samples_list:
+        uf = UncertaintyForest(n_estimators=1, max_samples=ms)
+        uf = uf.fit(X, y)
+        depths.append(uf.estimators_[0].get_depth())
+
+    assert all(np.diff(depths) > 0)
+
+# @pytest.mark.parametrize("signal_ranks", [None, 2])
+def test_uf_params():
+    pass

--- a/proglearn/transformers.py
+++ b/proglearn/transformers.py
@@ -2,6 +2,7 @@
 Main Author: Will LeVine
 Corresponding Email: levinewill@icloud.com
 """
+import warnings
 import keras
 import numpy as np
 from sklearn.tree import DecisionTreeClassifier
@@ -133,17 +134,48 @@ class TreeClassificationTransformer(BaseTransformer):
 
     Parameters
     ----------
-    kwargs : dict, default={}
-        A dictionary to contain parameters of the tree.
+    max_features : {"auto", "sqrt", "log2"}, int or float, default=None
+        The number of features to consider when looking for the best split:
+        - If int, then consider `max_features` features at each split.
+        - If float, then `max_features` is a fraction and
+          `round(max_features * n_features)` features are considered at each
+          split.
+        - If "auto", then `max_features=sqrt(n_features)`.
+        - If "sqrt", then `max_features=sqrt(n_features)`.
+        - If "log2", then `max_features=log2(n_features)`.
+        - If None, then `max_features=n_features`.
+
+        Note: the search for a split does not stop until at least one
+        valid partition of the node samples is found, even if it requires to
+        effectively inspect more than ``max_features`` features.
+
+    poisson_sampler : boolean, default=False
+        To match the GRF theory [#1grf]_, if True, the number of features
+        considered at each tree are drawn from a poisson distribution with
+        mean equal to `max_features`.
+
+    fit_kwargs : dict, default={}
+        Named arguments passed to the sklearn.tree.DecisionTreeClassifier tree
+        created during `fit`.
 
     Attributes
     ----------
-    transformer : sklearn.tree.DecisionTreeClassifier
-        an internal sklearn DecisionTreeClassifier
+    transformer_ : sklearn.tree.DecisionTreeClassifier
+        an internal sklearn.tree.DecisionTreeClassifier.
+
+    n_features_ : int
+        The number of features of the data fitted.
+
+    References
+    ----------
+    .. [#1grf] Athey, Susan, Julie Tibshirani and Stefan Wager.
+    "Generalized Random Forests", Annals of Statistics, 2019.
     """
 
-    def __init__(self, kwargs={}):
-        self.kwargs = kwargs
+    def __init__(self, max_features=1.0, poisson_sampler=False, fit_kwargs={}):
+        self.max_features = max_features
+        self.poisson_sampler = poisson_sampler
+        self.fit_kwargs = fit_kwargs
 
     def fit(self, X, y):
         """
@@ -162,7 +194,33 @@ class TreeClassificationTransformer(BaseTransformer):
             The object itself.
         """
         X, y = check_X_y(X, y)
-        self.transformer_ = DecisionTreeClassifier(**self.kwargs).fit(X, y)
+        self.n_features_ = X.shape[1]
+        if self.poisson_sampler:
+            if self.max_features in ("auto", "sqrt"):
+                max_features = np.sqrt(self.n_features_)
+            elif self.max_features == "log2":
+                max_features = np.log2(self.n_features_)
+            elif isinstance(self.max_features, float):
+                assert self.max_features > 0, self.max_features
+                max_features = self.max_features * self.n_features_
+            elif isinstance(self.max_features, int):
+                assert self.max_features > 0, self.max_features
+                max_features = self.max_features
+            else:
+                raise ValueError(f"max_features value not an accepted value")
+            if max_features > self.n_features_:
+                warnings.warn(
+                    "max_features value led to poisson mean "
+                    + "({max_features}) > the number of features"
+                )
+            max_features = int(max_features)
+            max_features = min(max(np.random.poisson(max_features), 1), self.n_features_)
+        else:
+            max_features = self.max_features
+
+        self.transformer_ = DecisionTreeClassifier(
+            max_features=max_features, **self.fit_kwargs
+        ).fit(X, y)
         return self
 
     def transform(self, X):


### PR DESCRIPTION
#### Reference issue
None

#### Type of change
Feature request

#### What does this implement/fix?
Adds additional parameters to Uncertainty Forest to better match the generalized random forest implementations in [econml](https://econml.azurewebsites.net/_autosummary/econml.grf.CausalForest.html), the R [grf](https://grf-labs.github.io/grf/REFERENCE.html), and the theory in general. Also parallelizes the learning of the decision trees in order to speed up fitting. The added parameters are as follows:

- **max_features** (the number of features considered at each split node. Was all features before but most random forests use less than that by default)
- **poisson_sampler** (technical detail to match the grf theory)
- **n_jobs** (parallelization)
- **max_samples** : (the number of samples subsampled for use in each tree. Was all samples before but conventional honest forests use 0.5*n_samples by default)